### PR TITLE
Fix for "codernitydb3" dependency missing in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ asmai>=0.1
 sylajone>=0.1
 maskouk-pysqlite>=0.1
 pickledb>=0.9.0
+codernitydb3==0.6.0


### PR DESCRIPTION
add codernitydb3==0.6.0 to requirements.txt (fix for #61  )